### PR TITLE
add support for objects property

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,25 @@ For detail, please check [cursor page](https://aframe.io/docs/components/cursor.
 
 ## Properties
 
-There is no property.
+| Property Name | Description |
+| -------- | ----------- |
+| objects | {String} Selector to use when limiting the objects to intersect. |
 
+```
+<a-entity
+  position="0 0 0"
+  id="camera"
+  camera
+  mouse-cursor="objects: .intersect-me"
+/>
+
+<a-entity
+  geometry="primitive: circle"
+  material="shader: flat"
+  class="intersect-me"
+  position="0 0 -10"
+/>
+```
 
 ## States
 
@@ -86,5 +103,3 @@ import 'aframe-mouse-cursor-component'
 
 - Now mouse cursor works in stereo mode on both desktop/mobile
 - `click` event won't be fired when mouse moves a lot after mouse down
-
-

--- a/dist/aframe-mouse-cursor-component.js
+++ b/dist/aframe-mouse-cursor-component.js
@@ -412,6 +412,40 @@
 	    return (0, _lodash2.default)(children);
 	  },
 
+    /**
+     * Update list of objects to test for intersection.
+     * @private
+     */
+    __getUserDefinedObjects: function __getUserDefinedObjects(selector) {
+      var getChildren = this.__getChildren;
+      var objectEls;
+      var objects = [];
+
+      // Push meshes onto list of objects to intersect.
+      objectEls = this.el.sceneEl.querySelectorAll(selector);
+
+      objectEls.forEach(function(el) {
+        var elChildren = getChildren(el.object3D);
+        objects.push.apply(objects, elChildren);
+      });
+
+      return objects;
+    },
+
+    /**
+     * Get children
+     * @private
+     */
+    __getObjects: function __getObjects() {
+      var data = this.data;
+
+      if (data.objects && typeof data.objects === 'string' && data.objects.length) {
+         return this.__getUserDefinedObjects(data.objects)
+      }
+
+      return this.__getAllChildren()
+    },
+
 
 	  /*====================================
 	  =            intersection            =
@@ -435,8 +469,8 @@
 	    __raycaster.ray.direction.set(__mouse.x, __mouse.y, 0.5).unproject(camera).sub(__raycaster.ray.origin).normalize();
 
 	    /* get objects intersected between mouse and camera */
-	    var children = this.__getAllChildren();
-	    var intersects = __raycaster.intersectObjects(children);
+	    var objects = this.__getObjects();
+	    var intersects = __raycaster.intersectObjects(objects);
 
 	    if (intersects.length > 0) {
 	      /* get the closest three obj */


### PR DESCRIPTION
The objects property is a string fed to document.querySelectorAll which will limit the objects that the mouse-cursor with intercept.